### PR TITLE
Allow domains where TLD is >6 characters

### DIFF
--- a/src/main/java/org/hazlewood/connor/bottema/emailaddress/Dragons.java
+++ b/src/main/java/org/hazlewood/connor/bottema/emailaddress/Dragons.java
@@ -132,7 +132,7 @@ final class Dragons {
 		final String letDig = "[a-zA-Z0-9]";
 		final String letDigHyp = "[a-zA-Z0-9-]";
 		final String rfcLabel = format("%s(?:%s{0,61}%s)?", letDig, letDigHyp, letDig);
-		final String rfc1035DomainName = format("%s(?:\\.%s)*\\.%s{2,6}", rfcLabel, rfcLabel, letter);
+		final String rfc1035DomainName = format("%s(?:\\.%s)*\\.%s{2,26}", rfcLabel, rfcLabel, letter);
 
 		//RFC 2822 3.4 Address specification
 		//domain text - non white space controls and the rest of ASCII chars not


### PR DESCRIPTION
It appears this library assumes domain TLD will not be more than 6 characters but these days, many are: https://newgtlds.icann.org/en/program-status/delegated-strings

I'm not terribly well versed in RFC 1035, but in [Section 2.3.1](https://tools.ietf.org/html/rfc1035#section-2.3.1) there doesn't seem to be any mention about a maximum length so I'm curious about how this constraint ended up in here, and how necessary it is. I wonder if it might make sense to remove this constraint altogether.

Regardless, this change is trivial; it just allows for domains with a longer TLD. The length that I changed it to is fairly arbitrary. From the aforementioned list, it seems the longest (as of March 2019) is 18 characters. This change increases it to 26 characters; again, fairly arbitrarily.

I don't often open pull-requests, but when I do, it's for a one character change.